### PR TITLE
Don't leave trailing whitespaces when processing _empty_ lines

### DIFF
--- a/lispindent.lisp
+++ b/lispindent.lisp
@@ -131,7 +131,7 @@
                           (+ (lparen-spaces-before lp)
                              extra-w))))))
         (setq curr-line (string-trim-blanks curr-line))
-        (dotimes (k curr-left-i) (write-char #\space))
+        (unless (zerop (length curr-line)) (dotimes (k curr-left-i) (write-char #\space)))
         (princ curr-line) (terpri)
         ;
         (let ((i 0) (n (length curr-line)) (escapep nil)


### PR DESCRIPTION
Currently, when indenting a form that includes a bunch of empty lines, `lispindent` will leave some trailing whitespaces in there:

```
(asdf:defsystem #:cg
  :description "Matteo's command guesser"
⌴⌴
  :author "Matteo Landi <matteo@matteolandi.net>"
  :license  "MIT"
```

This PR fixes the problem, by making sure whitespaces are written on stdout only if the current line, after it's been trimmed of all the whitespaces, winds up to be non-empty.

```
(asdf:defsystem #:cg
  :description "Matteo's command guesser"

  :author "Matteo Landi <matteo@matteolandi.net>"
  :license  "MIT"
```