### PR TITLE
Leave everything inside #| ... |# as is

### DIFF
--- a/lispindent.lisp
+++ b/lispindent.lisp
@@ -151,6 +151,7 @@
             (loop
               (when (>= i n) (return))
               (let ((c (char curr-line i)))
+                (when (and reader-macro-p (not (char= c #\|))) (setq reader-macro-p nil))
                 (cond ((and reader-macro-p (char= c #\|)) (setq reader-macro-p nil inside-comment-region-p t))
                       ((and inside-comment-region-p (char= c #\|)) (setq comment-region-maybe-end-p t))
                       ((and comment-region-maybe-end-p (char= c #\#)) (setq comment-region-maybe-end-p nil


### PR DESCRIPTION
Imagine you had a file that looked like this:

    #|
    I like quotes:

        Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nam hendrerit
        nisi sed sollicitudin pellentesque.
    |#
    (define hello-world ()
      (format t "Hello, world!~%"))

Feed it to lispindent and you would get back something like this (note
how the last line gets aligned to the indented _quote):

    #|
    I like quotes:

        Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nam hendrerit
        nisi sed sollicitudin pellentesque.
        |#
    (define hello-world ()
      (format t "Hello, world!~%"))

In addition, lispindent would now assume everything needed an extra
4 space of indentation -- this does not show up in the example, because
the code is already _properly_ indented.

Anyways, this commit tries to fix that by building a small _state
machine_ to handle with commented out regions:

- First it waits for the `#` reader macro character, followed by `|`
  (i.e. the start marker for these commented out regions)
- Then for `|` -- from this moment on, everything read from the input
  stream is kept _as is_
- Then waits for a `|` character again, follwed by a `#` (i.e. the end
  of the region)